### PR TITLE
Added crypto_pwhash_scryptsalsa208sha256 support for key derivation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ crypto_sign_SEEDBYTES,
 crypto_stream_KEYBYTES, crypto_stream_NONCEBYTES,
 crypto_generichash_BYTES, crypto_scalarmult_curve25519_BYTES,
 crypto_scalarmult_BYTES, crypto_sign_BYTES
+crypto_pwhash_scryptsalsa208sha256_SALTBYTES
+crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE
+crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_INTERACTIVE
+crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE
+crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE
+crypto_pwhash_scryptsalsa208sha256_SALTBYTES
+crypto_box_SEEDBYTES
 
 randombytes(l)
 
@@ -56,3 +63,5 @@ crypto_sign_open(sm, pk)
 crypto_stream(cnt, nonce = None, key = None)
 
 crypto_stream_xor(msg, cnt, nonce = None, key = None)
+
+crypto_pwhash_scryptsalsa208sha256(size, passwd, salt, opslimit = crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE, memlimit = crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE):

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -51,7 +51,13 @@ crypto_stream_NONCEBYTES = sodium.crypto_stream_noncebytes()
 crypto_generichash_BYTES = sodium.crypto_generichash_bytes()
 crypto_scalarmult_curve25519_BYTES = sodium.crypto_scalarmult_curve25519_bytes()
 crypto_scalarmult_BYTES = sodium.crypto_scalarmult_bytes()
-
+crypto_pwhash_scryptsalsa208sha256_SALTBYTES = sodium.crypto_pwhash_scryptsalsa208sha256_saltbytes()
+crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE = sodium.crypto_pwhash_scryptsalsa208sha256_opslimit_interactive()
+crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_INTERACTIVE = sodium.crypto_pwhash_scryptsalsa208sha256_memlimit_interactive()
+crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE = sodium.crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive()
+crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE = sodium.crypto_pwhash_scryptsalsa208sha256_memlimit_sensitive()
+crypto_pwhash_scryptsalsa208sha256_SALTBYTES = sodium.crypto_pwhash_scryptsalsa208sha256_saltbytes()
+crypto_box_SEEDBYTES = sodium.crypto_box_seedbytes()
 
 class CryptoGenericHashState(ctypes.Structure):
     _pack_ = 1
@@ -150,6 +156,15 @@ def crypto_generichash_final(state, outlen=crypto_generichash_BYTES):
     __check(sodium.crypto_generichash_final(ctypes.byref(state), buf, ctypes.c_size_t(outlen)))
     return buf.raw
 
+# crypto_pwhash_scryptsalsa208sha256(unsigned char * const out, unsigned long long outlen, const char * const passwd, unsigned long long passwdlen, const unsigned char * const salt, unsigned long long opslimit,size_t memlimit);
+def crypto_pwhash_scryptsalsa208sha256(size, passwd, salt, opslimit = crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE, memlimit = crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE):
+    outlen = ctypes.c_ulonglong(size)
+    out = ctypes.create_string_buffer(size)
+    passwdlen = ctypes.c_ulonglong(len(passwd))
+    opslimit = ctypes.c_ulonglong(opslimit)
+    memlimit = ctypes.c_size_t(memlimit)
+    __check(sodium.crypto_pwhash_scryptsalsa208sha256(out, outlen, passwd, passwdlen, str(salt), opslimit, memlimit))
+    return out.raw
 
 def randombytes(size):
     buf = ctypes.create_string_buffer(size)

--- a/pysodium/__init__.py
+++ b/pysodium/__init__.py
@@ -56,7 +56,6 @@ crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_INTERACTIVE = sodium.crypto_pwhash_s
 crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_INTERACTIVE = sodium.crypto_pwhash_scryptsalsa208sha256_memlimit_interactive()
 crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE = sodium.crypto_pwhash_scryptsalsa208sha256_opslimit_sensitive()
 crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE = sodium.crypto_pwhash_scryptsalsa208sha256_memlimit_sensitive()
-crypto_pwhash_scryptsalsa208sha256_SALTBYTES = sodium.crypto_pwhash_scryptsalsa208sha256_saltbytes()
 crypto_box_SEEDBYTES = sodium.crypto_box_seedbytes()
 
 class CryptoGenericHashState(ctypes.Structure):
@@ -157,13 +156,13 @@ def crypto_generichash_final(state, outlen=crypto_generichash_BYTES):
     return buf.raw
 
 # crypto_pwhash_scryptsalsa208sha256(unsigned char * const out, unsigned long long outlen, const char * const passwd, unsigned long long passwdlen, const unsigned char * const salt, unsigned long long opslimit,size_t memlimit);
-def crypto_pwhash_scryptsalsa208sha256(size, passwd, salt, opslimit = crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE, memlimit = crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE):
+def crypto_pwhash_scryptsalsa208sha256(size, passwd, salt, opslimit=crypto_pwhash_scryptsalsa208sha256_OPSLIMIT_SENSITIVE, memlimit=crypto_pwhash_scryptsalsa208sha256_MEMLIMIT_SENSITIVE):
     outlen = ctypes.c_ulonglong(size)
     out = ctypes.create_string_buffer(size)
     passwdlen = ctypes.c_ulonglong(len(passwd))
     opslimit = ctypes.c_ulonglong(opslimit)
     memlimit = ctypes.c_size_t(memlimit)
-    __check(sodium.crypto_pwhash_scryptsalsa208sha256(out, outlen, passwd, passwdlen, str(salt), opslimit, memlimit))
+    __check(sodium.crypto_pwhash_scryptsalsa208sha256(out, outlen, passwd, passwdlen, salt, opslimit, memlimit))
     return out.raw
 
 def randombytes(size):

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -107,7 +107,7 @@ class TestPySodium(unittest.TestCase):
     def test_crypto_pwhash_scryptsalsa208sha256(self):
         passwd = "howdy"
         outlen = 128
-        salt = pysodium.randombytes(pysodium.crypto_pwhash_scryptsalsa208sha256_SALTBYTES);
+        salt = pysodium.randombytes(pysodium.crypto_pwhash_scryptsalsa208sha256_SALTBYTES)
         output = pysodium.crypto_pwhash_scryptsalsa208sha256(outlen, passwd, salt)
         self.assertEqual(128, len(output))
         salt = b'12345678901234567890123456789012'

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -112,7 +112,7 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(128, len(output))
         salt = b'12345678901234567890123456789012'
         output = pysodium.crypto_pwhash_scryptsalsa208sha256(outlen, passwd, salt)
-        self.assertEqual(binascii.unhexlify(b'6af52bde42cb37deae6661ba684c78d006ed450542e812a7133f14d052fb59bd400476d2787834df1ab47576cb18da4881e5cea2cba4b676e2abc5411af80d5ddcf36217b43b3eab50a0067e820b5bcc215be0fc6ff016a717ff876304d51a87af7e8d0113f737a268e94a76abd4e690b0012a688e895e7edb93a030cd341b4f'), output)
+        self.assertEqual(binascii.unhexlify(b'6c3c08743a1389029ed68744f24dfd4cd550ad4a78af60e450f310f084bf0fc6fed23c22c71a427308cb4b98e8bbefc2be3c385c585f65b8a23682b44d8b45605f1fec2b1650c7cdedc2a73dcbed13d9cfb630cb207b3a8773b1ae0ff880c2cb5a855b49ab79f85dfd257f6f25e2da17248d81f4b8035220b467d9ca078be5f6'), output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_pysodium.py
+++ b/test/test_pysodium.py
@@ -104,6 +104,15 @@ class TestPySodium(unittest.TestCase):
         self.assertEqual(binascii.unhexlify(b"f798a189f195e66982105ffb640bb7757f579da31602fc93ec01ac56f85ac3c134a4547b733b46413042c9440049176905d3be59ea1c53f15916155c2be8241a38008b9a26bc35941e2444177c8ade6689de95264986d95889fb60e84629c9bd9a5acb1cc118be563eb9b3a4a472f82e09a7e778492b562ef7130e88dfe031c79db9d4f7c7a899151b9a475032b63fc385245fe054e3dd5a97a5f576fe064025d3ce042c566ab2c507b138db853e3d6959660996546cc9c4a6eafdc777c040d70eaf46f76dad3979e5c5360c3317166a1c894c94a371876a94df7628fe4eaaf2ccb27d5aaae0ad7ad0f9d4b6ad3b54098746d4524d38407a6deb3ab78fab78c9"),
                          output)
 
+    def test_crypto_pwhash_scryptsalsa208sha256(self):
+        passwd = "howdy"
+        outlen = 128
+        salt = pysodium.randombytes(pysodium.crypto_pwhash_scryptsalsa208sha256_SALTBYTES);
+        output = pysodium.crypto_pwhash_scryptsalsa208sha256(outlen, passwd, salt)
+        self.assertEqual(128, len(output))
+        salt = b'12345678901234567890123456789012'
+        output = pysodium.crypto_pwhash_scryptsalsa208sha256(outlen, passwd, salt)
+        self.assertEqual(binascii.unhexlify(b'6af52bde42cb37deae6661ba684c78d006ed450542e812a7133f14d052fb59bd400476d2787834df1ab47576cb18da4881e5cea2cba4b676e2abc5411af80d5ddcf36217b43b3eab50a0067e820b5bcc215be0fc6ff016a717ff876304d51a87af7e8d0113f737a268e94a76abd4e690b0012a688e895e7edb93a030cd341b4f'), output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since this seems to be the unofficial python3 branch of pysodium I figured I'd push the scrypt key derivation to here. You will notice that the tests are very slow and CPU bound now, I can change the default scrypt parameters to be INTERACTIVE instead of SENSITIVE to speed it up if we need.